### PR TITLE
Add Github actions for pull request and push

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Go project
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build:
+  format_test_and_build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,31 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Check formatting
+      run: sh -c ./scripts/gofmtcheck.sh
+
+    - name: Check for errors
+      run: sh -c ./scripts/errcheck.sh
+      
+    - name: Run the tests
+      run: go test -v ./redshift
+
+    - name: Build
+      run: go install

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,9 +21,6 @@ jobs:
     - name: Check formatting
       run: sh -c ./scripts/gofmtcheck.sh
 
-    - name: Check for errors
-      run: sh -c ./scripts/errcheck.sh
-      
     - name: Run the tests
       run: go test -v ./redshift
 


### PR DESCRIPTION
### What

Add a Github workflow to run on pull requests and pushes to `main`

### Why

Running this on pull requests will help catch any failing tests or formatting before pushing to `main`. Running this on pushes to `main` will help catch any failing tests or formatting before cutting releases.