### PR TITLE
GH-6 Add errcheck_excludes file and update check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,5 +24,8 @@ jobs:
     - name: Run the tests
       run: go test -v ./redshift
 
+    - name: Run errcheck
+      run: make errcheck
+
     - name: Build
       run: go install

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,6 @@
+(*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
+(*database/sql.DB).Close
+(*database/sql.DB).Exec
+(*database/sql.Rows).Close
+(*database/sql.Tx).Commit
+(*database/sql.Tx).Rollback

--- a/redshift/config.go
+++ b/redshift/config.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"database/sql"
 	"fmt"
+
 	_ "github.com/lib/pq"
 )
 

--- a/redshift/resource_redshift_schema_group_privilege.go
+++ b/redshift/resource_redshift_schema_group_privilege.go
@@ -233,14 +233,14 @@ func readRedshiftSchemaGroupPrivilege(d *schema.ResourceData, tx *sql.Tx) error 
 	}
 
 	var hasSchemaPrivilegeQuery = `
-			select 
-			case 
-				when charindex('U',split_part(split_part(array_to_string(nspacl, '|'), 'group ' || pu.groname,2 ) ,'/',1)) > 0 then 1 
-				else 0 
+			select
+			case
+				when charindex('U',split_part(split_part(array_to_string(nspacl, '|'), 'group ' || pu.groname,2 ) ,'/',1)) > 0 then 1
+				else 0
 			end as usage,
-			case 
-				when charindex('C',split_part(split_part(array_to_string(nspacl, '|'),'group ' || pu.groname,2 ) ,'/',1)) > 0 then 1 
-				else 0 
+			case
+				when charindex('C',split_part(split_part(array_to_string(nspacl, '|'),'group ' || pu.groname,2 ) ,'/',1)) > 0 then 1
+				else 0
 			end as create
 			from pg_group pu, pg_namespace nsp
 			where array_to_string(nsp.nspacl, '|') LIKE '%' || 'group ' || pu.groname || '=%'

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -445,8 +445,8 @@ func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error 
 	_, dropUserErr := tx.Exec("DROP USER " + d.Get("username").(string))
 
 	if dropUserErr != nil {
-		tx.Rollback()
 		return dropUserErr
+		tx.Rollback()
 	}
 
 	tx.Commit()

--- a/scripts/errcheck.sh
+++ b/scripts/errcheck.sh
@@ -9,9 +9,7 @@ if ! which errcheck > /dev/null; then
 fi
 
 err_files=$(errcheck -ignoretests \
-                     -ignore 'github.com/hashicorp/terraform/helper/schema:Set' \
-                     -ignore 'bytes:.*' \
-                     -ignore 'io:Close|Write' \
+                     -exclude errcheck_excludes.txt \
                      $(go list ./...| grep -v /vendor/))
 
 if [[ -n ${err_files} ]]; then
@@ -21,4 +19,5 @@ if [[ -n ${err_files} ]]; then
     exit 1
 fi
 
+echo "Found no errors not included in errcheck_excludes.txt"
 exit 0


### PR DESCRIPTION
### What | GH-6

* Add an `errcheck_excludes.txt` file to explicitly list unchecked errors that should not be reported by `make errcheck`
* Update `errcheck.sh` to use the above-mentioned exclude list and remove `-ignore` flags

### Why

* Running `make errcheck` currently reports 84 unchecked errors and correctly exits with a status code of 1, meaning it cannot be used in builds. Adding the exclusion list allows for resolving the unchecked errors one by one and easier checking for newly-introduced unchecked errors. A new issue can be raised for this.
* Not only is the `-ignore` flag deprecated, but the existing options were not changing the output of `errcheck` :man_shrugging:

Closes #6

@raymondberg