### PR TITLE
GH-9 - Handle unhandled db.Close() error

### DIFF
--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,5 +1,4 @@
 (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
-(*database/sql.DB).Close
 (*database/sql.DB).Exec
 (*database/sql.Rows).Close
 (*database/sql.Tx).Commit

--- a/redshift/config.go
+++ b/redshift/config.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"database/sql"
 	"fmt"
+	"log"
 
 	_ "github.com/lib/pq"
 )
@@ -34,8 +35,14 @@ func (c *Config) Client() (*Client, error) {
 		c.database)
 
 	db, err := sql.Open("postgres", conninfo)
+	const fName = "redshift/config.go Client()"
 	if err != nil {
-		db.Close()
+		log.Printf("Error in %v: %v", fName, err)
+		err1 := db.Close()
+		if err1 != nil {
+			log.Printf("Error in %v: %v", fName, err)
+			return nil, err1
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
### What

Handle the unhandled `db.Close()` error in `redshift/config.go`

### Why

This is showing up as an unchecked error and is currently being excluded in `errcheck_excludes.txt`. The output of the error should at least be reported. I loosely followed [some of these guidelines](https://qvault.io/2020/03/09/wrapping-errors-in-go-how-to-handle-nested-errors/).
