### PR TITLE
#19 Add quota support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ date.
 Note that schemas are the lowest level of granularity here. Tables should be
 created by some other tool, for instance flyway.
 
+# Support
+
+This module supports terraform version >0.12 for Redshift versions >1.0.14677.
+
 # Get it:
 
 1. Navigate to the [releases] and download the desired plugin binary, likely the latest
@@ -72,8 +76,12 @@ resource "redshift_schema" "testschema" {
   schema_name = "testschema"  # Schema names are not immutable
   owner = "${redshift_user.testuser.id}"  # This defaults to the current user (eg as specified in the provider config) if empty
   cascade_on_delete = true
+  quota = 2048  # in MB
 }
 ```
+
+Note that quotas can either be 0 (unlimited) or [some number greater than the
+Redshift minimums][redshift-schema-parameters].
 
 ### Give that group select, insert and references privileges on that schema
 
@@ -213,3 +221,4 @@ Navigate to the [project tag](https://github.com/coopergillan/terraform-provider
 
 [installing_plugin]: https://www.terraform.io/docs/extend/how-terraform-works.html#implied-local-mirror-directories
 [releases]: https://github.com/coopergillan/terraform-provider-redshift/releases
+[redshift-schema-parameters]: https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_SCHEMA.html#r_CREATE_SCHEMA-parameters

--- a/example/root.tf
+++ b/example/root.tf
@@ -14,46 +14,52 @@ variable "database_test" {
 
 // Set up connection to Redshift
 provider redshift {
-  url = "${var.url}",
-  user = "${var.username}",
-  password = "${var.password}",
+  url      = "${var.url}"
+  user     = "${var.username}"
+  password = "${var.password}"
   database = "${var.database_primary}"
-  sslmode = "disable"
+  sslmode  = "disable"
 }
 
 // Create an initial user
-resource "redshift_user" "testuser"{
-  username = "testusernew",
-  password = "Testpass123"
+resource "redshift_user" "testuser" {
+  username         = "testusernew"
+  password         = "Testpass123"
   connection_limit = "4"
-  createdb = true
+  createdb         = true
 }
 
 // Create another user
-resource "redshift_user" "testuser2"{
-  username = "testuser8",
-  password = "Testpass123"
+resource "redshift_user" "testuser2" {
+  username         = "testuser8"
+  password         = "Testpass123"
   connection_limit = "1"
-  createdb = true
+  createdb         = true
 }
 
 // Create a group with the two above-created users
 resource "redshift_group" "testgroup" {
   group_name = "testgroup"
-  users = ["${redshift_user.testuser.id}", "${redshift_user.testuser2.id}"]
+  users      = ["${redshift_user.testuser.id}", "${redshift_user.testuser2.id}"]
 }
 
 // Create a `testschemax` schema
 resource "redshift_schema" "testschema" {
-  schema_name = "testschemax",
+  schema_name       = "testschemax"
   cascade_on_delete = true
+}
+
+// Create a `testscratch` schema with a quota limit
+resource "redshift_schema" "test_quota_limited_schema" {
+  schema_name = "testschemay"
+  quota       = 4096
 }
 
 // Add priviliges for the above-created schema
 resource "redshift_group_schema_privilege" "testgroup_testchema_privileges" {
   schema_id = "${redshift_schema.testschema.id}"
-  group_id = "${redshift_group.testgroup.id}"
-  select = true
-  insert = true
-  update = true
+  group_id  = "${redshift_group.testgroup.id}"
+  select    = true
+  insert    = true
+  update    = true
 }

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"database/sql"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,6 +43,12 @@ func redshiftSchema() *schema.Resource {
 				Description: "Keyword that indicates to automatically drop all objects in the schema, such as tables and functions. By default it doesn't for your safety",
 				Default:     false,
 			},
+			"quota": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "In megabytes, the maximum amount of disk space that the specified schema can use",
+				Default:     0,
+			},
 		},
 	}
 }
@@ -73,10 +80,17 @@ func resourceRedshiftSchemaCreate(d *schema.ResourceData, meta interface{}) erro
 
 	var createStatement string = "CREATE SCHEMA " + d.Get("schema_name").(string)
 
-	//If no owner is specified it defaults to client user
+	//If an owner is specified, set authorization with mapped username
 	if v, ok := d.GetOk("owner"); ok {
 		var usernames = GetUsersnamesForUsesysid(redshiftClient, []interface{}{v.(int)})
 		createStatement += " AUTHORIZATION " + usernames[0]
+	}
+
+	//If no quota is specified it defaults to unlimited
+	if v, ok := d.GetOk("quota"); ok && v.(int) != 0 {
+		createStatement += " QUOTA " + strconv.Itoa(v.(int)) + " MB"
+	} else {
+		createStatement += " QUOTA UNLIMITED"
 	}
 
 	log.Print("Create Schema statement: " + createStatement)
@@ -120,9 +134,13 @@ func readRedshiftSchema(d *schema.ResourceData, db *sql.DB) error {
 	var (
 		schemaName string
 		owner      int
+		quota      int
 	)
 
-	err := db.QueryRow("select nspname, nspowner from pg_namespace where oid = $1", d.Id()).Scan(&schemaName, &owner)
+	err := db.QueryRow(`
+			select trim(nspname) as nspname, nspowner, coalesce(quota, 0) as quota from pg_namespace
+			left join svv_schema_quota_state on svv_schema_quota_state.schema_id = pg_namespace.oid
+			where pg_namespace.oid = $1`, d.Id()).Scan(&schemaName, &owner, &quota)
 
 	if err != nil {
 		log.Print(err)
@@ -131,6 +149,7 @@ func readRedshiftSchema(d *schema.ResourceData, db *sql.DB) error {
 
 	d.Set("schema_name", schemaName)
 	d.Set("owner", owner)
+	d.Set("quota", quota)
 
 	return nil
 }
@@ -158,6 +177,18 @@ func resourceRedshiftSchemaUpdate(d *schema.ResourceData, meta interface{}) erro
 		var username = GetUsersnamesForUsesysid(redshiftClient, []interface{}{d.Get("owner").(int)})
 
 		if _, err := tx.Exec("ALTER SCHEMA " + d.Get("schema_name").(string) + " OWNER TO " + username[0]); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("quota") {
+		quota := "UNLIMITED"
+
+		if v, ok := d.GetOk("quota"); ok && v.(int) != 0 {
+			quota = strconv.Itoa(v.(int)) + " MB"
+		}
+
+		if _, err := tx.Exec("ALTER SCHEMA " + d.Get("schema_name").(string) + " QUOTA " + quota); err != nil {
 			return err
 		}
 	}

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -138,9 +138,10 @@ func readRedshiftSchema(d *schema.ResourceData, db *sql.DB) error {
 	)
 
 	err := db.QueryRow(`
-			select trim(nspname) as nspname, nspowner, coalesce(quota, 0) as quota from pg_namespace
-			left join svv_schema_quota_state on svv_schema_quota_state.schema_id = pg_namespace.oid
-			where pg_namespace.oid = $1`, d.Id()).Scan(&schemaName, &owner, &quota)
+			SELECT trim(nspname) AS nspname, nspowner, coalesce(quota, 0) AS quota
+			FROM pg_namespace LEFT JOIN svv_schema_quota_state
+				ON svv_schema_quota_state.schema_id = pg_namespace.oid
+			WHERE pg_namespace.oid = $1`, d.Id()).Scan(&schemaName, &owner, &quota)
 
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
__Problem__

In mid-2020, Redshift added [quota
support](https://aws.amazon.com/about-aws/whats-new/2020/06/announcing-storage-controls-for-schemas-amazon-redshift/)
to limit the size of schemas. This feature is not yet supported in the
provider. Full details in #19

__Solution__

@coopergillan and I spiked a basic capability. After a few hours of
debugging I verified the code can perform both creates and updates using
quotas. Docs included in solution

The key design idea was that unlimited quotas are specified as strings,
whereas all other quotas are specified as numbers. To get around this,
we can use a fairly common standard of saying 0 = unlimited. There
appears to be no conflicts with other behaviors since 0 is not supported
on Redshift today due to a (at time of authorship) 2048MB lower-limit.
That limit seems to imply that it would be unlikely AWS would ever add a
"0 MB" limit that behaved differently than unlimited.

While GB is the default unit of measure in the documentation, getting
granularity of MB seems to cover all use-cases without having to do
string validation on a string-type parameter: e.g. '25 GB'. That said,
I'm open to the explicit string being a better use-case.