### PR TITLE
GH-22 - Run builds for other Go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,21 @@ jobs:
 
   format_test_and_build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version:
+          - 1.12
+          - 1.13
+          - 1.14
+          - 1.15
+          - 1.16
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ${{ matrix.go-version }}
 
     - name: Check formatting
       run: sh -c ./scripts/gofmtcheck.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,10 @@ jobs:
           - 1.14
           - 1.15
           - 1.16
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
### What

* Run Github Actions workflow for other versions of Go
* Run it for Windows and Mac OS X as well

### Why

* See #22 below for more detail, but the module itself is set as Go version 1.12 and the latest version of Go is 1.16. Why not test all of them?
* [`scripts/dist.sh` already distributes the code for each operating system](https://github.com/coopergillan/terraform-provider-redshift/blob/2b1116af72fe14cf7c9ca512096b01388c923c8a/scripts/dist.sh#L5) so why should the builds not run against each also?

Relates to #22 

@raymondberg