### PR TITLE
GH-9 - Handle unchecked tx.Commit() errors

### DIFF
--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -2,5 +2,4 @@
 (*database/sql.DB).Close
 (*database/sql.DB).Exec
 (*database/sql.Rows).Close
-(*database/sql.Tx).Commit
 (*database/sql.Tx).Rollback

--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -176,7 +176,12 @@ func resourceRedshiftDatabaseUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -100,7 +100,12 @@ func resourceRedshiftGroupCreate(d *schema.ResourceData, meta interface{}) error
 		return readErr
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -121,7 +126,12 @@ func resourceRedshiftGroupRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -212,7 +222,12 @@ func resourceRedshiftGroupUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -201,7 +201,12 @@ func resourceRedshiftSchemaUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 

--- a/redshift/resource_redshift_schema_group_privilege.go
+++ b/redshift/resource_redshift_schema_group_privilege.go
@@ -178,7 +178,12 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 		return readErr
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -197,7 +202,12 @@ func resourceRedshiftSchemaGroupPrivilegeRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -325,7 +335,12 @@ func resourceRedshiftSchemaGroupPrivilegeUpdate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -367,7 +382,12 @@ func resourceRedshiftSchemaGroupPrivilegeDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -161,7 +161,12 @@ func resourceRedshiftUserCreate(d *schema.ResourceData, meta interface{}) error 
 		return readErr
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -182,7 +187,12 @@ func resourceRedshiftUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -302,7 +312,12 @@ func resourceRedshiftUserUpdate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 
@@ -449,7 +464,12 @@ func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error 
 		tx.Rollback()
 	}
 
-	tx.Commit()
+	commitErr := tx.Commit()
+	if commitErr != nil {
+		log.Print("Error committing transaction: ", commitErr)
+		return commitErr
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What

Handle `tx.Commit()` errors in several files.

### Why

`make errcheck` [currently ignores](https://github.com/coopergillan/terraform-provider-redshift/blob/86be64680213f6640a0efd626976ac984a96ca65/errcheck_excludes.txt#L5) these unchecked errors, but, seeing as [`tx.Commit()` does indeed return an error](https://golang.org/pkg/database/sql/#Tx.Commit), it should be surfaced and returned. This change prints the text of the error and returns any errors from `tx.Commit()`.

Relates to #9

@raymondberg