### PR TITLE
avoid creating resources if they exists in the DB, when terraform is created

### DIFF
--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -41,7 +41,7 @@ func redshiftGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Required: false,
-				Default:  false,
+				Default:  true,
 			},
 		},
 	}
@@ -72,9 +72,13 @@ func resourceRedshiftGroupCreate(d *schema.ResourceData, meta interface{}) error
 		panic(txErr)
 	}
 
-	if d.Get("fail_if_exists").(bool) == true {
+	if d.Get("fail_if_exists").(bool) == false {
 
-		exists, _ := existsGroupName(redshiftClient, d.Get("group_name").(string))
+		exists, err := existsGroupName(redshiftClient, d.Get("group_name").(string))
+
+		if err != nil {
+			return fmt.Errorf("Could not create redshift group: %s", err)
+		}
 
 		if exists == true {
 			log.Print("Group already created in the database, skipping group creation")


### PR DESCRIPTION
Hello,

Thanks for adapting this module. At Wetransfer, we are thinking of using your module to terraform all our Redshift infrastructure objects( users, groups, schemas).

We have found one problem most of the redshift groups, and redshift schemas are already created on our database. So when we try to first create these objects, from Terraform we got an error, as the resource already exists in the database.

This PR adds a flag in some terraform objects, like groups and schemas to allow resource creation if already exists in the database the first time.

Please let me know if something is not clear. 